### PR TITLE
Add proxyUrls column to UserSettings model

### DIFF
--- a/src/db/migrations/.snapshot-postgres.json
+++ b/src/db/migrations/.snapshot-postgres.json
@@ -483,6 +483,15 @@
           "primary": false,
           "nullable": true,
           "mappedType": "string"
+        },
+        "proxy_urls": {
+          "name": "proxy_urls",
+          "type": "text[]",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "array"
         }
       },
       "name": "user_settings",

--- a/src/db/migrations/Migration20231229214215.ts
+++ b/src/db/migrations/Migration20231229214215.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231229214215 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "user_settings" add column "proxy_urls" text[] null;');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "user_settings" drop column "proxy_urls";');
+  }
+
+}

--- a/src/db/models/UserSettings.ts
+++ b/src/db/models/UserSettings.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { ArrayType, Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
 @Entity({ tableName: 'user_settings' })
 export class UserSettings {
@@ -14,7 +14,7 @@ export class UserSettings {
   @Property({ name: 'default_subtitle_language', nullable: true })
   defaultSubtitleLanguage?: string | null;
 
-  @Property({ name: 'proxy_urls', nullable: true, type: 'text[]' })
+  @Property({ name: 'proxy_urls', type: ArrayType, nullable: true })
   proxyUrls?: string[] | null;
 }
 

--- a/src/db/models/UserSettings.ts
+++ b/src/db/models/UserSettings.ts
@@ -13,6 +13,9 @@ export class UserSettings {
 
   @Property({ name: 'default_subtitle_language', nullable: true })
   defaultSubtitleLanguage?: string | null;
+
+  @Property({ name: 'proxy_urls', nullable: true, type: 'text[]' })
+  proxyUrls?: string[] | null;
 }
 
 export interface UserSettingsDTO {
@@ -20,6 +23,7 @@ export interface UserSettingsDTO {
   applicationTheme?: string | null;
   applicationLanguage?: string | null;
   defaultSubtitleLanguage?: string | null;
+  proxyUrls?: string[] | null;
 }
 
 export function formatUserSettings(
@@ -30,5 +34,6 @@ export function formatUserSettings(
     applicationTheme: userSettings.applicationTheme,
     applicationLanguage: userSettings.applicationLanguage,
     defaultSubtitleLanguage: userSettings.defaultSubtitleLanguage,
+    proxyUrls: userSettings.proxyUrls,
   };
 }

--- a/src/routes/users/settings.ts
+++ b/src/routes/users/settings.ts
@@ -41,6 +41,7 @@ export const userSettingsRouter = makeRouter((app) => {
           applicationLanguage: z.string().nullable().optional(),
           applicationTheme: z.string().nullable().optional(),
           defaultSubtitleLanguage: z.string().nullable().optional(),
+          proxyUrls: z.string().array().nullable().optional(),
         }),
       },
     },
@@ -64,6 +65,7 @@ export const userSettingsRouter = makeRouter((app) => {
         settings.defaultSubtitleLanguage = body.defaultSubtitleLanguage;
       if (body.applicationTheme !== undefined)
         settings.applicationTheme = body.applicationTheme;
+      if (body.proxyUrls !== undefined) settings.proxyUrls = body.proxyUrls;
 
       await em.persistAndFlush(settings);
       return formatUserSettings(settings);


### PR DESCRIPTION
This pull request resolves [#539](https://github.com/movie-web/movie-web/issues/539)

Adds the proxyUrls column to the UserSettings model, allowing users to sync proxies between devices.

[I have created a sister PR in the frontend repo with the required changes.](https://github.com/movie-web/movie-web/pull/643)

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
