### PR TITLE
Add config support for SSL postgres connections.

### DIFF
--- a/src/config/orm.ts
+++ b/src/config/orm.ts
@@ -12,6 +12,8 @@ export const ormConfigSchema = z.object({
   postgres: z.object({
     // connection URL for postgres database
     connection: z.string(),
+    // whether to use SSL for the connection
+    ssl: z.coerce.boolean().default(false),
   }),
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -48,6 +48,9 @@ export const configSchema = z.object({
     // Enable debug logging for MikroORM - Outputs queries and entity management logs
     // Do NOT use in production, leaks all sensitive data
     debugLogging: z.coerce.boolean().default(false),
+
+    // Enable SSL for the postgres connection
+    ssl: z.coerce.boolean().default(false),
   }),
   crypto: z.object({
     // session secret. used for signing session tokens

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -1,4 +1,4 @@
 import { ormConf } from '@/config/orm';
 import { makeOrmConfig } from '@/modules/mikro/orm';
 
-export default makeOrmConfig(ormConf.postgres.connection);
+export default makeOrmConfig(ormConf.postgres.connection, ormConf.postgres.ssl);

--- a/src/modules/mikro/index.ts
+++ b/src/modules/mikro/index.ts
@@ -18,6 +18,7 @@ export async function setupMikroORM() {
     conf.postgres.connection,
     conf.postgres.debugLogging,
     (msg) => log.info(msg),
+    conf.postgres.ssl,
   );
 
   if (conf.postgres.syncSchema) {

--- a/src/modules/mikro/orm.ts
+++ b/src/modules/mikro/orm.ts
@@ -2,7 +2,10 @@ import { Options } from '@mikro-orm/core';
 import { MikroORM, PostgreSqlDriver } from '@mikro-orm/postgresql';
 import path from 'path';
 
-export function makeOrmConfig(url: string): Options<PostgreSqlDriver> {
+export function makeOrmConfig(
+  url: string,
+  ssl: boolean,
+): Options<PostgreSqlDriver> {
   return {
     type: 'postgresql',
     clientUrl: url,
@@ -13,6 +16,11 @@ export function makeOrmConfig(url: string): Options<PostgreSqlDriver> {
       pathTs: './migrations',
       path: './migrations',
     },
+    driverOptions: {
+      connection: {
+        ssl,
+      },
+    },
   };
 }
 
@@ -20,9 +28,10 @@ export async function createORM(
   url: string,
   debug: boolean,
   log: (msg: string) => void,
+  ssl: boolean,
 ) {
   return await MikroORM.init<PostgreSqlDriver>({
-    ...makeOrmConfig(url),
+    ...makeOrmConfig(url, ssl),
     logger: log,
     debug,
   });


### PR DESCRIPTION
This pull request resolves [#646](https://github.com/movie-web/movie-web/issues/646)

Adds a new config option (`postgres.ssl`), this enables SSL support for postgres connections.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
