### PR TITLE
Swap to using `pnpm exec` instead of `npx` in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   },
   "scripts": {
     "dev": "nodemon -r tsconfig-paths/register src/main.ts",
-    "build": "npm run build:pre && npm run build:compile",
+    "build": "pnpm run build:pre && pnpm run build:compile",
     "start": "node dist/main.js",
     "lint": "eslint --ext .ts,.js,.json,.tsx src/",
     "lint:fix": "eslint --fix --ext .ts,.js,.json,.tsx src/",
     "build:pre": "rimraf dist/",
     "build:compile": "tsc && tsc-alias",
     "preinstall": "npx -y only-allow pnpm",
-    "migration:create": "npx -y mikro-orm migration:create",
-    "migration:up": "npx -y mikro-orm migration:up",
-    "migration:down": "npx -y mikro-orm migration:down"
+    "migration:create": "pnpm exec mikro-orm migration:create",
+    "migration:up": "pnpm exec mikro-orm migration:up",
+    "migration:down": "pnpm exec mikro-orm migration:down"
   },
   "mikro-orm": {
     "useTsNode": true,


### PR DESCRIPTION
This pull request resolves [#662](https://github.com/movie-web/movie-web/issues/662)

Changes everything but the `preinstall` script which helps with using `pnpm`.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
