### PR TITLE
update deprecated composer syntax; change body format in API request

### DIFF
--- a/.docker/development/docker-compose.yml
+++ b/.docker/development/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     links: 
       - postgres:postgres
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+      - PGWEB_DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
     depends_on:
       - postgres
 

--- a/src/services/captcha.ts
+++ b/src/services/captcha.ts
@@ -4,16 +4,14 @@ import { StatusError } from '@/services/error';
 export async function isValidCaptcha(token: string): Promise<boolean> {
   if (!conf.captcha.secret)
     throw new Error('isValidCaptcha() is called but no secret set');
+  const formData = new URLSearchParams();
+  formData.append('secret', conf.captcha.secret);
+  formData.append('response', token);
   const res = await fetch('https://www.google.com/recaptcha/api/siteverify', {
     method: 'POST',
-    body: JSON.stringify({
-      secret: conf.captcha.secret,
-      response: token,
-    }),
-    headers: {
-      'content-type': 'application/json',
-    },
+    body: formData,
   });
+
   const json = await res.json();
   return !!json.success;
 }


### PR DESCRIPTION
This pull request resolves [#544](https://github.com/movie-web/movie-web/issues/544)

I changed the body format of the request sent to the Google Recaptcha API. Moreover, I updated a deprecated env variable name in docker development.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
