### PR TITLE
Add a success message to the base path

### DIFF
--- a/src/modules/fastify/routes.ts
+++ b/src/modules/fastify/routes.ts
@@ -1,3 +1,4 @@
+import { indexRouter } from '@/routes';
 import { loginAuthRouter } from '@/routes/auth/login';
 import { manageAuthRouter } from '@/routes/auth/manage';
 import { metaRouter } from '@/routes/meta';
@@ -25,4 +26,5 @@ export async function setupRoutes(app: FastifyInstance) {
   await app.register(userSettingsRouter.register);
   await app.register(userGetRouter.register);
   await app.register(metricsRouter.register);
+  await app.register(indexRouter.register);
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,14 @@
+import { version } from '@/config';
+import { handle } from '@/services/handler';
+import { makeRouter } from '@/services/router';
+
+export const indexRouter = makeRouter((app) => {
+  app.get(
+    '/',
+    handle(async () => {
+      return {
+        message: `Backend is working as expected (${version})`,
+      };
+    }),
+  );
+});


### PR DESCRIPTION
Previously when navigating to the `/` route, it would show a 404 message since this route isn't registered and caused a lot of confusion amongst people new to self hosting.

This PR adds a simple message (same as on the proxies) to help users better understand that everything is working as expected.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
